### PR TITLE
Upgrade wtf_wikipedia to 4.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dumpster-dive",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -109,9 +109,9 @@
       "dev": true
     },
     "cross-fetch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.0.tgz",
-      "integrity": "sha512-P0tdN3ZcwhZQsqUiBnyH02mduL2sBIG1lESy+rUALVDXobpSxNzJhzx4cbzRcSsy3FcJ40Ogc9sjIYrrPs3BVg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.1.tgz",
+      "integrity": "sha1-lshZEE113vyWf7XbYkdOdUJrArA=",
       "requires": {
         "node-fetch": "2.1.2",
         "whatwg-fetch": "2.0.4"
@@ -930,9 +930,9 @@
       "dev": true
     },
     "wtf_wikipedia": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/wtf_wikipedia/-/wtf_wikipedia-4.2.0.tgz",
-      "integrity": "sha512-yIArcZWLWWuH1gBuquO/2ABj8c+ZgmJJWP2cTkRZ6I6JDH4HumCHCU5M786lAFYPf82tfRTRn/i0Dt2DTeNuNA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/wtf_wikipedia/-/wtf_wikipedia-4.2.1.tgz",
+      "integrity": "sha512-i+ZuUkWmcb1qQgn3ATu+32DAUlSh32RER6jvtEOUMrnyp7pbcmFSz/rq14nGxzBwNNEz2R54mtLycVw76nQRbA==",
       "requires": {
         "cross-fetch": "^2.1.0",
         "jshashes": "1.0.7"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettysize": "1.1.0",
     "sunday-driver": "1.0.1",
     "worker-nodes": "1.6.0",
-    "wtf_wikipedia": "4.2.0",
+    "wtf_wikipedia": "4.2.1",
     "yargs": "11.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I ran into the issues that were fixed in https://github.com/spencermountain/wtf_wikipedia/pull/117 while using dumpster-dive, and noticed that the wtf_wikipedia dependency hadn't been updated after the release. This should fix it.