### PR TITLE
Support dump filenames with dates

### DIFF
--- a/bin/dumpster.js
+++ b/bin/dumpster.js
@@ -61,8 +61,8 @@ if (!file) {
 }
 //try to make-up the language name for the db
 let db = 'wikipedia'
-if (file.match(/-latest-pages-articles/)) {
-  db = file.match(/([a-z]+)-latest/) || []
+if (file.match(/-(latest|\d{8})-pages-articles/)) {
+  db = file.match(/([a-z]+)-(latest|\d{8})-pages-articles/) || []
   db = db[1] || 'wikipedia'
 }
 options.file = file


### PR DESCRIPTION
The filenames of Wikipedia dumps don't always match the `{name}-latest-pages-articles.xml` format. The dumps often have a date instead of `latest` in the filename, e.g. http://dumps.wikimedia.your.org/enwiki/20180620/enwiki-20180620-pages-articles.xml.bz2

This PR improves the detection of the Wikipedia dump for the database name.

One thing that came to mind is that being able to explicitly set the database name as a command-line option might be a good idea, but I decided to not touch that part for now.