### PR TITLE
Take custom title and pageID

### DIFF
--- a/src/worker/02-parseWiki.js
+++ b/src/worker/02-parseWiki.js
@@ -43,8 +43,8 @@ const parseWiki = function(page, options, worker) {
       data = options.custom(doc);
     }
     //use the title/pageID from the xml
-    data.title = page.title || data.title;
-    data.pageID = page.pageID || data.pageID;
+    data.title = data.title || page.title;
+    data.pageID = data.pageID || page.pageID;
     data._id = data._id || data.title;
     data._id = encode.encodeStr(data._id);
     return data;


### PR DESCRIPTION
This change takes the title and pageID from the `custom` function's data, if they are present, otherwise from the parsed page, which is the opposite of the previous scenario.
In the previous scenario, the user couldn't set the title and pageID himself in the `custom` function, and was forced to get the title and pageID from the `wtf_wikipedia` parsing.