### PR TITLE
await on done function for promise resolution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,8 @@ const main = (options, done) => {
 
   workers.on('allWorkersFinished', () => {
     logger.stop();
-    oneSec(() => {
-      done();
+    oneSec(async () => {
+      await done();
       oneSec(() => {
         finish(options);
       });


### PR DESCRIPTION
Previously, `done` function at
https://github.com/spencermountain/dumpster-dive/blob/f9b8c433ac645f5afb2becd6bb1f1244c6a50d01/src/index.js#L44
wasn't awaited on, and so async functions that took more than 1 second would get killed because of the `process.exit()` in the `finish` function.