### PR TITLE
adding db_url, db, and collection options to cli mode

### DIFF
--- a/bin/dumpster.js
+++ b/bin/dumpster.js
@@ -15,7 +15,10 @@ let argv = yargs
   .describe('plaintext', 'include page plaintext? [false]')
   .describe('verbose', 'run in verbose mode [false]')
   .describe('verbose_skip', 'log skipped disambigs & redirects [false]')
-  .describe('workers', 'run in verbose mode [CPUCount]').argv;
+  .describe('workers', 'run in verbose mode [CPUCount]')
+  .describe('db_url', 'the location of the mongo database [false]')
+  .describe('db', 'name of the database to store data [false]')
+  .describe('collection', 'name of collection to store data [false]').argv;
 
 const defaults = {
   batch_size: 500,
@@ -54,11 +57,19 @@ if (!file) {
   process.exit(1);
 }
 //try to make-up the language name for the db
-let db = 'wikipedia';
-if (file.match(/-(latest|\d{8})-pages-articles/)) {
-  db = file.match(/([a-z]+)-(latest|\d{8})-pages-articles/) || [];
-  db = db[1] || 'wikipedia';
+if (!argv.db) {
+  let db = 'wikipedia';
+  if (file.match(/-(latest|\d{8})-pages-articles/)) {
+    db = file.match(/([a-z]+)-(latest|\d{8})-pages-articles/) || [];
+    db = db[1] || 'wikipedia';
+  }
+  options.db = db;
+} else {
+  options.db = argv.db;
 }
+
+options.db_url = argv.db_url;
+options.collection = argv.collection;
 options.file = file;
-options.db = db;
+
 dumpster(options);

--- a/src/lib/open-db.js
+++ b/src/lib/open-db.js
@@ -18,7 +18,7 @@ const openDb = async function (options) {
         reject(err);
       }
       const db = client.db(options.db);
-      const collection = db.collection(config.collection);
+      const collection = db.collection((options.collection) ? options.collection : config.collection);
       //we use all of these.
       const obj = {
         db: db,


### PR DESCRIPTION
The current cli module doesn't support explicitly setting the database name, collection name, or db_url options from the command-line. These are important options for users who use `dumpster-dive` to periodically download and preprocess Wikipedia and don't want to fumble around with Javascript.

This PR expands on the current cli tool by adding the three options `db_url`, `db`, and `collection`.

example:
```bash
dumpster-dive afwiki-latest-pages-articles.xml --db=wiki_data_2022_04_07 --collection=afrikaans_pages
```