### PR TITLE
Update wikipedia data path example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ wget https://dumps.wikimedia.org/afwiki/latest/afwiki-latest-pages-articles.xml.
 ```
 
 the english dump is 16Gb. The [download page](https://dumps.wikimedia.org/enwiki/latest/) is confusing, but you'll want this file:
-`https://dumps.wikimedia.org/`**${LANG}**`wiki/latest/`**${LANG}**`wiki-latest-pages-articles.xml.bz2 `
+`https://dumps.wikimedia.org/${LANG}wiki/latest/${LANG}wiki-latest-pages-articles.xml.bz2 `
 
 for example: `https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2 `
 

--- a/README.md
+++ b/README.md
@@ -123,11 +123,15 @@ mongod --config /mypath/to/mongod.conf
 The Afrikaans wikipedia (around 93,000 articles) only takes a few minutes to download, and 5 mins to load into mongo on a macbook:
 
 ```bash
-# dowload an xml dump (38mb, couple minutes)
+# download an xml dump (38mb, couple minutes)
 wget https://dumps.wikimedia.org/afwiki/latest/afwiki-latest-pages-articles.xml.bz2
 ```
 
-the english dump is 16Gb. The [download page](https://dumps.wikimedia.org/enwiki/latest/) is confusing, but you'll want this file: `${LANG}wiki-latest-pages-articles.xml.bz2 `
+the english dump is 16Gb. The [download page](https://dumps.wikimedia.org/enwiki/latest/) is confusing, but you'll want this file:
+`https://dumps.wikimedia.org/`**${LANG}**`wiki/latest/`**${LANG}**`wiki-latest-pages-articles.xml.bz2 `
+
+for example: `https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2 `
+
 
 ### 4️⃣ unzip it
 


### PR DESCRIPTION
Updated the README.md for step 3 "download a wikipedia"
I fixed a small typo "dowload" --> "download"
I made the example url more explicit to include the full url with the ${LANG} replacement in two spots and the actual url to the english version