### PR TITLE
fixed wget examples so they have horizontal scrolling and a copy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,12 @@ wget https://dumps.wikimedia.org/afwiki/latest/afwiki-latest-pages-articles.xml.
 ```
 
 the english dump is 16Gb. The [download page](https://dumps.wikimedia.org/enwiki/latest/) is confusing, but you'll want this file:
-`https://dumps.wikimedia.org/${LANG}wiki/latest/${LANG}wiki-latest-pages-articles.xml.bz2 `
+<pre>wget https://dumps.wikimedia.org/<b>${LANG}</b>wiki/latest/<b>${LANG}</b>wiki-latest-pages-articles.xml.bz2</pre>
 
-for example: `https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2 `
-
+for example, the English version is:
+```bash
+wget https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2
+```
 
 ### 4️⃣ unzip it
 


### PR DESCRIPTION
On the README.md, updated step 3 so that it horizontally scrolls when the line is too long and it has a copy button for the English wiki example.