### PR TITLE
allow upserting mongo docs on re-runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Or use a multithread bzip2 implementation like `lbzip2`, which takes around 4 mi
 
 ```bash
 brew install lbzip2
-bzip2 -d ./afwiki-latest-pages-articles.xml.bz2
+lbzip2 -d ./afwiki-latest-pages-articles.xml.bz2
 ```
 
 The english wikipedia is around 100Gb.


### PR DESCRIPTION
I saw that the Readme said on multiple runs an 'upsert' is used but when I looked in the code it seemed not, it uses `insertMany'. So I tried to verify by dl'ing simplewiki, dumpster-dive it, gave me 247004 documents. 

On a new run this time with `--plaintext=true` all entries were recognized as duplicates (existing), but not updated. When deleting one entry from the collection and re-running 

`dumpster simplewiki-20240501-pages-articles.xml --plaintext=true`

this time the one entry was recreated with the plaintext field.

So I had a look into mongo and they have 'bulk ops', https://www.mongodb.com/docs/manual/core/bulk-write-operations/

Btw. insertMany is using bulkWrite under the hood, so they say. 
bulkWrite also supports updates, etc. so with some help from chatgpt I updated the code to use bulkwrite.

In my few local runs it even seems the bulkwrite is faster than the insertMany on the initial creation.

<img width="1348" alt="Screenshot 2024-06-02 at 20 48 19" src="https://github.com/spencermountain/dumpster-dive/assets/673459/ebc030f3-b1a5-432f-99de-dc37a6fc63a8">

Btw, there is also a commit which adds a missing 'L' to the docs when using 'lbzip2', which I forgot in the other pr, sorry.

Regarding your question: "Is there a way to add this as a node dependency, so we can add it to the library??"

It seems the only way to do this would be to wrap the lbzip2 lib in a node package. If you think that would be worth the effort I might give it a try.

A few more questions:

What do you think about mentioning https://github.com/huggingface/Mongoku in the docs? It's very convenient to explore the data in the mongodb.

What do you think about mentioning/adding info regarding indexing?

It's seems dumpster-dip has the more recent code. Do you envision dumpster-dive to work the same way regarding eg. the way a local wtf can be used? I might port it then.

Anything else you think would be important for this project to do? Not sure how long I'll work with it but until then I'm happy to contribute.